### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SkullGaming31/OpenDevBot/security/code-scanning/8](https://github.com/SkullGaming31/OpenDevBot/security/code-scanning/8)

**How to, in general terms, fix the problem:**  
To address this issue, add a `permissions` section at the top level of the workflow (right after the `name:` or `on:` fields), or at the job level (inside `jobs.test:`). This section should provide only those permissions required for the workflow to run successfully. If no step requires write access, the minimal permissions should be set: `contents: read`.

**Single best way to fix without changing existing functionality:**  
Since none of the workflow steps require write access, add a top-level `permissions:` block specifying `contents: read`. This will apply to all jobs within the workflow unless overridden later. The recommended place for this block is directly after the `name: CI` line (before `on:`).

**Specific changes:**  
- Edit `.github/workflows/ci.yml`
- Insert the following after line 1 (`name: CI`):
  ```yaml
  permissions:
    contents: read
  ```
- No new methods, imports, or additional definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
