### PR TITLE
fix(auth): remove dev-only Twurple internals mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ Recommended next steps
 - Remove the temporary developer-only Twurple mapping in `getChatAuthProvider()` once the SDK surface is stabilized or the workaround is no longer needed.
 - Harden EventSub subscription reconciliation with exponential backoff and idempotent create-or-ensure logic.
 
+Recent follow-up (2025-10-13)
+- Removed developer-only mutation of Twurple provider internals from `src/auth/authProvider.ts` and added a unit test `src/__tests__/authProviderInternals.test.ts` that asserts internals are not mutated. This reduces tech-debt and keeps provider behavior within supported APIs.
+
 ---
 
 For older historical entries, add them under new dated headings following this format.

--- a/src/__tests__/authProviderInternals.test.ts
+++ b/src/__tests__/authProviderInternals.test.ts
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals';
+
+describe('authProvider internals safety', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
+
+    test('getChatAuthProvider does not mutate provider internals', async () => {
+        await jest.isolateModulesAsync(async () => {
+            const botToken = { user_id: '659523613', access_token: 'botacc', refresh_token: 'r', scope: ['chat:read'], expires_in: 1000, obtainmentTimestamp: 1 };
+            const findOne = (jest.fn() as any);
+            findOne.mockResolvedValue(botToken);
+            const TokenModel = { findOne } as any;
+            jest.doMock('../database/models/tokenModel', () => ({ TokenModel }));
+
+            // Create a mock provider that exposes _intentToUserId and _userIdToIntents
+            const onRefresh = jest.fn();
+            class MockProvider {
+                onRefresh: any;
+                addUserForToken: any;
+                addUser: any;
+                // internals that should NOT be mutated by getChatAuthProvider
+                _intentToUserId: any;
+                _userIdToIntents: any;
+                constructor() {
+                    this.onRefresh = onRefresh;
+                    this.addUserForToken = jest.fn();
+                    this.addUser = jest.fn();
+                    // Start with empty/undefined internals to simulate the provider's private state
+                    this._intentToUserId = undefined;
+                    this._userIdToIntents = undefined;
+                }
+            }
+            jest.doMock('@twurple/auth', () => ({ RefreshingAuthProvider: MockProvider }));
+
+            const { getChatAuthProvider } = await import('../auth/authProvider');
+            const provider: any = await getChatAuthProvider();
+
+            // provider should be an instance of MockProvider
+            expect(provider).toBeInstanceOf(MockProvider as any);
+
+            // Assert that we did not create or mutate internal maps/objects on the provider
+            expect(provider._intentToUserId).toBeUndefined();
+            expect(provider._userIdToIntents).toBeUndefined();
+        });
+    });
+});

--- a/src/auth/authProvider.ts
+++ b/src/auth/authProvider.ts
@@ -114,36 +114,11 @@ export async function getChatAuthProvider(): Promise<RefreshingAuthProvider> {
 		}
 	}
 
-	// Dev-only: ensure internal intent maps advertise the 'chat' intent for the bot user.
-	try {
-		const shouldForce = process.env.Enviroment !== 'prod' || process.env.DEBUG_AUTH_PROVIDER === 'true';
-		if (shouldForce) {
-			const inspect = provider as any;
-			const botId = String(botEnvId);
-			if (inspect._intentToUserId) {
-				if (inspect._intentToUserId instanceof Map) {
-					inspect._intentToUserId.set('chat', botId);
-				} else if (typeof inspect._intentToUserId === 'object') {
-					inspect._intentToUserId['chat'] = botId;
-				}
-			}
-			if (inspect._userIdToIntents) {
-				if (inspect._userIdToIntents instanceof Map) {
-					let s = inspect._userIdToIntents.get(botId);
-					if (!s) s = new Set();
-					s.add('chat');
-					inspect._userIdToIntents.set(botId, s);
-				} else if (typeof inspect._userIdToIntents === 'object') {
-					inspect._userIdToIntents[botId] = Array.isArray(inspect._userIdToIntents[botId])
-						? Array.from(new Set([...(inspect._userIdToIntents[botId] || []), 'chat']))
-						: ['chat'];
-				}
-			}
-			console.log('ChatAuthProvider: forced chat intent mapping for bot', botId);
-		}
-	} catch (e) {
-		console.warn('ChatAuthProvider: failed to force internal intent mapping', e);
-	}
+	// Note: previously we forced internal Twurple intent mappings here as a developer-only
+	// workaround when SDK internals changed. That code was removing encapsulation and
+	// caused maintenance burden. We now rely on supported public APIs and routine
+	// addUser/addUserForToken fallbacks above. If a provider implementation change is
+	// required in future, add an explicit adapter instead of mutating internals.
 
 	return provider;
 }


### PR DESCRIPTION
This PR removes a developer-only workaround that mutated Twurple provider internals to force the bot to advertise the chat intent. Mutating SDK internals caused maintenance burden and hidden side-effects. The provider now relies on public APIs and fallback addUser/addUserForToken behavior instead.

Changes:

Remove internal _intentToUserId / _userIdToIntents mutation in [authProvider.ts](vscode-file://vscode-app/c:/Users/canad/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Add [authProviderInternals.test.ts](vscode-file://vscode-app/c:/Users/canad/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to assert provider internals are not mutated.
Update [CHANGELOG.md](vscode-file://vscode-app/c:/Users/canad/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with the change.
Tests: All unit tests pass locally (9 suites, 14 tests).

Notes:

This is non-breaking. If Twurple exposes a different public API in future, consider an adapter rather than mutating internals.
Merge when happy; I can then remove the feature-branch or squash/merge depending on your preferred merge strategy.