### PR TITLE
lurk: delete saved lurk message when auto-removed

### DIFF
--- a/src/Commands/Information/lurk.ts
+++ b/src/Commands/Information/lurk.ts
@@ -90,6 +90,8 @@ const lurk: Command = {
 					if (savedLurkMessage) {
 						await savedLurkMessage.deleteOne();
 					}
+					// Explicitly ensure no status report is sent when lurk is turned off
+					shouldReportStatus = false;
 					break;
 			}
 			if (shouldReportStatus) {

--- a/src/Commands/Information/lurk.ts
+++ b/src/Commands/Information/lurk.ts
@@ -8,11 +8,12 @@ import logger from '../../util/logger';
 export const lurkingUsers: Set<string> = new Set<string>();
 const lurk: Command = {
 	name: 'lurk',
-	description: 'Display a Lurk message and send it to anyone that tages you in chat',
+	description: 'Display a Lurk message and send it to anyone that tags you in chat',
 	usage: '!lurk [on|off] (lurkMessage)',
 	execute: async (channel: string, user: string, args: string[], text: string, msg: ChatMessage) => {
 		void text;
 		const chatClient = await getChatClient();
+		let shouldReportStatus = false;
 		try {
 			if (channel !== 'canadiendragon') return;
 			logger.debug('hit this point');
@@ -27,30 +28,35 @@ const lurk: Command = {
 				case 'on':
 					logger.debug('hit on-case');
 					if (message) {
-						if (savedLurkMessage) {
-							savedLurkMessage.message = message;
-							savedLurkMessage.displayName = msg.userInfo.displayName;
-							savedLurkMessage.displayNameLower = String(msg.userInfo.displayName).toLowerCase();
-							await savedLurkMessage.save();
-						} else {
-							const newLurkMessage = new LurkMessageModel({
-								id: msg.userInfo.userId,
-								displayName: msg.userInfo.displayName,
-								displayNameLower: String(msg.userInfo.displayName).toLowerCase(),
-								message: message,
-							});
-							await newLurkMessage.save();
+						try {
+							if (savedLurkMessage) {
+								savedLurkMessage.message = message;
+								savedLurkMessage.displayName = msg.userInfo.displayName;
+								savedLurkMessage.displayNameLower = String(msg.userInfo.displayName).toLowerCase();
+								await savedLurkMessage.save();
+							} else {
+								const newLurkMessage = new LurkMessageModel({
+									id: msg.userInfo.userId,
+									displayName: msg.userInfo.displayName,
+									displayNameLower: String(msg.userInfo.displayName).toLowerCase(),
+									message: message,
+								});
+								await newLurkMessage.save();
+							}
+							lurkingUsers.add(user);
+							shouldReportStatus = true;
+							await chatClient.say(channel, `${user} is now lurking with the message: ${message}`);
+						} catch (err) {
+							logger.warn('Failed to save lurk document for user', { user: msg.userInfo.userId, err });
+							await chatClient.say(channel, `Sorry ${msg.userInfo.displayName}, enabling lurk failed due to an internal error.`);
 						}
-						lurkingUsers.add(user);
-						await chatClient.say(channel, `${user} is now lurking with the message: ${message}`);
 					} else {
 						// Ensure the DB has a lurk document for this user and that displayNameLower is populated
 						let lurkDoc = savedLurkMessage;
 						if (lurkDoc) {
 							lurkDoc.displayName = msg.userInfo.displayName;
-							if (!lurkDoc.displayNameLower) {
-								lurkDoc.displayNameLower = String(msg.userInfo.displayName).toLowerCase();
-							}
+							// Always update the lowercase copy to keep it in sync with displayName
+							lurkDoc.displayNameLower = String(msg.userInfo.displayName).toLowerCase();
 							if (!lurkDoc.message) {
 								lurkDoc.message = '';
 							}
@@ -65,12 +71,14 @@ const lurk: Command = {
 						// persist any created/updated document
 						try {
 							await lurkDoc.save();
+							const lurkMessage = lurkDoc.message || '';
+							lurkingUsers.add(user);
+							shouldReportStatus = true;
+							await chatClient.say(channel, `${user} is now lurking ${lurkMessage ? `with the message: ${lurkMessage}` : 'No Lurk Message was Provided'}`);
 						} catch (err) {
 							logger.warn('Failed to save lurk document for user', { user: msg.userInfo.userId, err });
+							await chatClient.say(channel, `Sorry ${msg.userInfo.displayName}, enabling lurk failed due to an internal error.`);
 						}
-						const lurkMessage = lurkDoc.message || '';
-						lurkingUsers.add(user);
-						await chatClient.say(channel, `${msg.userInfo.displayName} is now lurking ${lurkMessage ? `with the message: ${lurkMessage}` : 'No Lurk Message was Provided'}`);
 					}
 					break;
 				case 'off':
@@ -84,8 +92,10 @@ const lurk: Command = {
 					}
 					break;
 			}
-			await sleep(5000);
-			await chatClient.say(channel, `Currently ${lurkingUsers.size} people are lurking. ${numLurkers}`);
+			if (shouldReportStatus) {
+				await sleep(5000);
+				await chatClient.say(channel, `Currently ${lurkingUsers.size} people are lurking. ${numLurkers}`);
+			}
 		} catch (error) {
 			logger.error('Error with the Lurk Command', error);
 		}

--- a/src/EventSubEvents.ts
+++ b/src/EventSubEvents.ts
@@ -68,7 +68,8 @@ export async function initializeTwitchEventSub(): Promise<void> {
 							await chatClient.say(info.name, 'dont forget you can join the Discord Server too, https://discord.com/invite/6TGV75sDjW');
 						}
 					}
-					lurkingUsers.length = 0;
+					// clear set of lurking users when stream ends
+					lurkingUsers.clear();
 					await LurkMessageModel.deleteMany({});
 				} catch (error) {
 					logger.error(error);

--- a/src/__tests__/commands_lurk.test.ts
+++ b/src/__tests__/commands_lurk.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.resetModules();
+jest.setTimeout(20000);
+
+const sayMockCmd = jest.fn().mockResolvedValue(undefined);
+
+// Mock the chat client without importing the real module to avoid side-effects
+jest.doMock('../chat', () => ({
+  getChatClient: jest.fn().mockResolvedValue({ say: sayMockCmd }),
+}));
+
+describe('lurk command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a lurk doc with displayNameLower when used with a message', async () => {
+    // prepare DB mock: no existing doc
+    const findOneMock = jest.fn().mockResolvedValue(null);
+    const countMock = jest.fn().mockResolvedValue(1);
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const LurkMessageModel = jest.fn().mockImplementation((doc: any) => ({ ...doc, save: saveMock }));
+    (LurkMessageModel as any).findOne = findOneMock;
+    (LurkMessageModel as any).countDocuments = countMock;
+
+    jest.doMock('../database/models/LurkModel', () => ({ LurkMessageModel }));
+
+    const lurkModule = await import('../Commands/Information/lurk');
+    const cmd = lurkModule.default as any;
+
+    // clear state
+    lurkModule.lurkingUsers.clear();
+
+    const fakeMsg: any = { userInfo: { userId: 'u-100', displayName: 'Tester' } };
+
+    await cmd.execute('canadiendragon', 'tester', ['on', 'hello', 'world'], '!lurk on hello world', fakeMsg);
+
+    const mocked = (await import('../database/models/LurkModel')) as any;
+    expect(mocked.LurkMessageModel).toHaveBeenCalled();
+    const createdArg = mocked.LurkMessageModel.mock.calls[0][0];
+    expect(createdArg).toMatchObject({ id: 'u-100', displayName: 'Tester', displayNameLower: 'tester', message: 'hello world' });
+    expect(lurkModule.lurkingUsers.has('tester')).toBe(true);
+    expect(sayMockCmd).toHaveBeenCalledWith('canadiendragon', 'tester is now lurking with the message: hello world');
+  });
+
+  it('creates/updates lurk doc when used without a message', async () => {
+    const findOneMock = jest.fn().mockResolvedValue(null);
+    const countMock = jest.fn().mockResolvedValue(1);
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const LurkMessageModel = jest.fn().mockImplementation((doc: any) => ({ ...doc, save: saveMock }));
+    (LurkMessageModel as any).findOne = findOneMock;
+    (LurkMessageModel as any).countDocuments = countMock;
+
+    jest.doMock('../database/models/LurkModel', () => ({ LurkMessageModel }));
+
+    const lurkModule = await import('../Commands/Information/lurk');
+    const cmd = lurkModule.default as any;
+
+    lurkModule.lurkingUsers.clear();
+
+    const fakeMsg: any = { userInfo: { userId: 'u-101', displayName: 'NoMsgUser' } };
+
+    await cmd.execute('canadiendragon', 'nomsguser', ['on'], '!lurk on', fakeMsg);
+
+    const mocked = (await import('../database/models/LurkModel')) as any;
+    expect(mocked.LurkMessageModel).toHaveBeenCalled();
+    const createdArg = mocked.LurkMessageModel.mock.calls[0][0];
+    expect(createdArg).toMatchObject({ id: 'u-101', displayName: 'NoMsgUser', displayNameLower: 'nomsguser', message: '' });
+    expect(lurkModule.lurkingUsers.has('nomsguser')).toBe(true);
+    expect(sayMockCmd).toHaveBeenCalledWith('canadiendragon', expect.stringContaining('is now lurking'));
+  });
+
+  it('removes user and deletes saved doc on off', async () => {
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+    const findOneMock = jest.fn().mockResolvedValue({ deleteOne: deleteMock });
+    const countMock = jest.fn().mockResolvedValue(1);
+    const LurkMessageModel = jest.fn().mockImplementation(() => ({}));
+    (LurkMessageModel as any).findOne = findOneMock;
+    (LurkMessageModel as any).countDocuments = countMock;
+
+    jest.doMock('../database/models/LurkModel', () => ({ LurkMessageModel }));
+
+    const lurkModule = await import('../Commands/Information/lurk');
+    const cmd = lurkModule.default as any;
+
+    // pre-populate
+    lurkModule.lurkingUsers.clear();
+    lurkModule.lurkingUsers.add('tooff');
+
+    const fakeMsg: any = { userInfo: { userId: 'u-102', displayName: 'ToOff' } };
+
+    await cmd.execute('canadiendragon', 'tooff', ['off'], '!lurk off', fakeMsg);
+
+    expect(lurkModule.lurkingUsers.has('tooff')).toBe(false);
+    expect(sayMockCmd).toHaveBeenCalledWith('canadiendragon', 'ToOff is no longer lurking');
+    const mocked = (await import('../database/models/LurkModel')) as any;
+    expect(mocked.LurkMessageModel.findOne).toHaveBeenCalledWith({ id: 'u-102' });
+  });
+});

--- a/src/__tests__/lurk.autoRemove.test.ts
+++ b/src/__tests__/lurk.autoRemove.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.resetModules();
+
+const sayMock = jest.fn().mockResolvedValue(undefined);
+const onMessageMock = jest.fn();
+const deleteOneMock = jest.fn().mockResolvedValue({});
+
+jest.doMock('../database/models/LurkModel', () => ({
+  LurkMessageModel: {
+    deleteOne: deleteOneMock,
+    findOne: jest.fn().mockResolvedValue(null),
+  },
+}));
+
+// Preserve other exports from the real module but mock `getChatClient`
+const actualChat = jest.requireActual('../chat');
+jest.doMock('../chat', () => ({
+  ...actualChat,
+  getChatClient: jest.fn().mockResolvedValue({ say: sayMock, onMessage: onMessageMock }),
+}));
+
+describe('lurk auto-removal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes user from lurkingUsers, deletes DB entry, and announces', async () => {
+    const { handleAutoRemoveLurk } = await import('../chat');
+    const { lurkingUsers } = await import('../Commands/Information/lurk');
+
+    // ensure clean state
+    lurkingUsers.length = 0;
+
+    const testUser = 'testuser';
+    lurkingUsers.push(testUser);
+
+    // call helper directly instead of initializing full chat subsystem
+    const fakeMsg: any = {
+      userInfo: { userId: 'u-123', displayName: 'TestUser', isMod: false, isBroadcaster: false },
+      channelId: 'chan-1',
+      id: 'm-1',
+    };
+
+    await handleAutoRemoveLurk('#channel', testUser, 'hello folks', fakeMsg, { say: sayMock } as any);
+
+    expect(lurkingUsers).not.toContain(testUser);
+    expect(deleteOneMock).toHaveBeenCalledWith({ id: 'u-123' });
+    expect(sayMock).toHaveBeenCalledWith('#channel', 'TestUser is no longer lurking');
+  });
+});

--- a/src/__tests__/lurk.autoRemove.test.ts
+++ b/src/__tests__/lurk.autoRemove.test.ts
@@ -6,45 +6,139 @@ const onMessageMock = jest.fn();
 const deleteOneMock = jest.fn().mockResolvedValue({});
 
 jest.doMock('../database/models/LurkModel', () => ({
-  LurkMessageModel: {
-    deleteOne: deleteOneMock,
-    findOne: jest.fn().mockResolvedValue(null),
-  },
+	LurkMessageModel: {
+		deleteOne: deleteOneMock,
+		findOne: jest.fn().mockResolvedValue(null),
+	},
 }));
 
 // Preserve other exports from the real module but mock `getChatClient`
 const actualChat = jest.requireActual('../chat');
 jest.doMock('../chat', () => ({
-  ...actualChat,
-  getChatClient: jest.fn().mockResolvedValue({ say: sayMock, onMessage: onMessageMock }),
+	...actualChat,
+	getChatClient: jest.fn().mockResolvedValue({ say: sayMock, onMessage: onMessageMock }),
 }));
 
 describe('lurk auto-removal', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-  it('removes user from lurkingUsers, deletes DB entry, and announces', async () => {
-    const { handleAutoRemoveLurk } = await import('../chat');
-    const { lurkingUsers } = await import('../Commands/Information/lurk');
+	it('removes user from lurkingUsers, deletes DB entry, and announces', async () => {
+		const { handleAutoRemoveLurk } = await import('../chat');
+		const { lurkingUsers } = await import('../Commands/Information/lurk');
 
-    // ensure clean state
-    lurkingUsers.length = 0;
+		// ensure clean state
+		lurkingUsers.clear();
 
-    const testUser = 'testuser';
-    lurkingUsers.push(testUser);
+		const testUser = 'testuser';
+		lurkingUsers.add(testUser);
 
-    // call helper directly instead of initializing full chat subsystem
-    const fakeMsg: any = {
-      userInfo: { userId: 'u-123', displayName: 'TestUser', isMod: false, isBroadcaster: false },
-      channelId: 'chan-1',
-      id: 'm-1',
-    };
+		// call helper directly instead of initializing full chat subsystem
+		const fakeMsg: any = {
+			userInfo: { userId: 'u-123', displayName: 'TestUser', isMod: false, isBroadcaster: false },
+			channelId: 'chan-1',
+			id: 'm-1',
+		};
 
-    await handleAutoRemoveLurk('#channel', testUser, 'hello folks', fakeMsg, { say: sayMock } as any);
+		await handleAutoRemoveLurk('#channel', testUser, 'hello folks', fakeMsg, { say: sayMock } as any);
 
-    expect(lurkingUsers).not.toContain(testUser);
-    expect(deleteOneMock).toHaveBeenCalledWith({ id: 'u-123' });
-    expect(sayMock).toHaveBeenCalledWith('#channel', 'TestUser is no longer lurking');
-  });
+		expect(lurkingUsers.has(testUser)).toBe(false);
+		expect(deleteOneMock).toHaveBeenCalledWith({ id: 'u-123' });
+		expect(sayMock).toHaveBeenCalledWith('#channel', 'TestUser is no longer lurking');
+	});
+
+	it('does nothing when message is a command (starts with !)', async () => {
+		const { handleAutoRemoveLurk } = await import('../chat');
+		const { lurkingUsers } = await import('../Commands/Information/lurk');
+
+		lurkingUsers.clear();
+		const testUser = 'cmduser';
+		lurkingUsers.add(testUser);
+
+		const fakeMsg: any = {
+			userInfo: { userId: 'u-222', displayName: 'CmdUser', isMod: false, isBroadcaster: false },
+			channelId: 'chan-1',
+			id: 'm-2',
+		};
+
+		await handleAutoRemoveLurk('#channel', testUser, '!notarealmessage', fakeMsg, { say: sayMock } as any);
+
+		expect(lurkingUsers.has(testUser)).toBe(true);
+		expect(deleteOneMock).not.toHaveBeenCalled();
+		expect(sayMock).not.toHaveBeenCalledWith('#channel', 'CmdUser is no longer lurking');
+	});
+
+	it('does nothing when user is not in lurkingUsers', async () => {
+		const { handleAutoRemoveLurk } = await import('../chat');
+		const { lurkingUsers } = await import('../Commands/Information/lurk');
+
+		lurkingUsers.clear(); // empty
+
+		const fakeMsg: any = {
+			userInfo: { userId: 'u-333', displayName: 'NoLurker', isMod: false, isBroadcaster: false },
+			channelId: 'chan-1',
+			id: 'm-3',
+		};
+
+		await handleAutoRemoveLurk('#channel', 'someoneElse', 'hello', fakeMsg, { say: sayMock } as any);
+
+		expect(deleteOneMock).not.toHaveBeenCalled();
+		expect(sayMock).not.toHaveBeenCalledWith('#channel', expect.stringContaining('no longer lurking'));
+	});
+
+	it('logs a warning when DB deletion fails but still attempts announcement', async () => {
+		const { handleAutoRemoveLurk } = await import('../chat');
+		const { lurkingUsers } = await import('../Commands/Information/lurk');
+		const logger = await import('../util/logger');
+
+		lurkingUsers.clear();
+		const testUser = 'dbfail';
+		lurkingUsers.add(testUser);
+
+		// simulate DB delete failure
+		deleteOneMock.mockRejectedValueOnce(new Error('db down'));
+		const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => { });
+
+		const fakeMsg: any = {
+			userInfo: { userId: 'u-444', displayName: 'DBFail', isMod: false, isBroadcaster: false },
+			channelId: 'chan-1',
+			id: 'm-4',
+		};
+
+		await handleAutoRemoveLurk('#channel', testUser, 'hello', fakeMsg, { say: sayMock } as any);
+
+		expect(warnSpy).toHaveBeenCalledWith('Failed to delete saved lurk message for user', expect.objectContaining({ user: 'u-444' }));
+		expect(sayMock).toHaveBeenCalledWith('#channel', 'DBFail is no longer lurking');
+		warnSpy.mockRestore();
+	});
+
+	it('logs a warning when announcement fails after successful DB delete', async () => {
+		const { handleAutoRemoveLurk } = await import('../chat');
+		const { lurkingUsers } = await import('../Commands/Information/lurk');
+		const logger = await import('../util/logger');
+
+		lurkingUsers.clear();
+		const testUser = 'sayfail';
+		lurkingUsers.add(testUser);
+
+		// ensure DB delete succeeds
+		deleteOneMock.mockResolvedValueOnce({});
+		// simulate say failure
+		sayMock.mockRejectedValueOnce(new Error('network'));
+
+		const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => { });
+
+		const fakeMsg: any = {
+			userInfo: { userId: 'u-555', displayName: 'SayFail', isMod: false, isBroadcaster: false },
+			channelId: 'chan-1',
+			id: 'm-5',
+		};
+
+		await handleAutoRemoveLurk('#channel', testUser, 'hello', fakeMsg, { say: sayMock } as any);
+
+		expect(deleteOneMock).toHaveBeenCalledWith({ id: 'u-555' });
+		expect(warnSpy).toHaveBeenCalledWith('Failed to announce lurk removal', expect.any(Error));
+		warnSpy.mockRestore();
+	});
 });

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -130,7 +130,10 @@ export async function initializeChat(): Promise<void> {
 			return await LurkMessageModel.findOne({ displayName: re }).exec();
 		} catch (e) {
 			logger.warn(`Failed to lookup saved lurk message for ${displayName}: ${e}`);
-			return await LurkMessageModel.findOne({ displayName: displayName }).exec();
+			// The fallback exact, case-sensitive lookup is unlikely to help after an error
+			// (and may return null even if a differently-cased record exists). Return null
+			// to indicate lookup failure and avoid misleading exact-match queries.
+			return null;
 		}
 	};
 

--- a/src/database/models/LurkModel.ts
+++ b/src/database/models/LurkModel.ts
@@ -3,12 +3,15 @@ import { Schema, model } from 'mongoose';
 export interface LurkMessage extends Document {
 	id: string;
 	displayName: string;
+	displayNameLower: string;
 	message: string;
 }
 
 const LurkMessageSchema = new Schema<LurkMessage>({
 	id: { type: String, required: true, unique: true, index: true },
 	displayName: { type: String, required: true },
+	// Lowercase copy of displayName for efficient case-insensitive lookups
+	displayNameLower: { type: String, required: true, index: true },
 	message: { type: String, required: false, default: 'No Afk message set' },
 });
 

--- a/src/database/models/LurkModel.ts
+++ b/src/database/models/LurkModel.ts
@@ -11,6 +11,8 @@ const LurkMessageSchema = new Schema<LurkMessage>({
 	id: { type: String, required: true, unique: true, index: true },
 	displayName: { type: String, required: true },
 	// Lowercase copy of displayName for efficient case-insensitive lookups
+	// NOTE: This field must be kept in sync with `displayName` whenever it is
+	// updated (e.g., on create/update) to ensure lookups are reliable.
 	displayNameLower: { type: String, required: true, index: true },
 	message: { type: String, required: false, default: 'No Afk message set' },
 });


### PR DESCRIPTION
When a user marked as lurking sends a non-command message, remove them from the in-memory `lurkingUsers` list and delete their saved lurk message from the database. Log any DB deletion failures. This PR implements that behavior and includes tests/updates where applicable.